### PR TITLE
Fix authenticator None user control

### DIFF
--- a/aegis/authenticators/basic.py
+++ b/aegis/authenticators/basic.py
@@ -22,6 +22,7 @@ class BasicAuth(BaseAuthenticator):
 
     async def get_user(self, credentials) -> dict:
         """Retrieve user with credentials."""
+        return credentials
 
     async def decode(self, token: str, verify=True) -> dict:
         """

--- a/aegis/decorators.py
+++ b/aegis/decorators.py
@@ -16,7 +16,7 @@ def login_required(func):
         if not isinstance(request, web.Request):
             raise TypeError(f"Invalid Type '{type(request)}'")
 
-        if not hasattr(request, "user"):
+        if not getattr(request, "user", None):
             return AuthRequiredException.make_response(request)
         return func(request)
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -34,6 +34,20 @@ async def test_login_required_handles_no_user():
         assert response.status == 401
         auth_required.assert_called_once_with(stub_request)
 
+async def test_login_required_returns_401_if_request_user_is_invalid():
+    with patch("aegis.decorators.AuthRequiredException.make_response") as auth_required:
+
+        @decorators.login_required
+        async def test_view(request):
+            return web.json_response({})
+
+        stub_request = make_mocked_request("GET", "/", headers={"authorization": "x"})
+        stub_request.user = None
+        auth_required.return_value.status = 401
+        response = test_view(stub_request)
+
+        assert response.status == 401
+        auth_required.assert_called_once_with(stub_request)
 
 async def test_login_required_returns_200_if_request_has_user():
     @decorators.login_required


### PR DESCRIPTION
### Summary
Changed the request user control of the authenticators to not accept `None `users.

### Related Issues
#46 

### Contributor Checklist

- [x] This PR requires new unit tests (make sure tests are included)
- [ ] This PR requires to update the documentation (make sure the docs are up-to-date)
- [x] This PR is backward compatible
- [ ] This PR changes the current API (all API changes needs to be approved by [mgurdal](https://github.com/mgurdal))
